### PR TITLE
Improve fragment handling

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -149,7 +149,7 @@ func executeStep(
 
 			for _, point := range path {
 				// look for the selection with that name
-				for _, selection := range selectedFields(target) {
+				for _, selection := range graphql.SelectedFields(target) {
 					// if we still have to walk down the selection but we found the right branch
 					if selection.Name == point {
 						target = selection.SelectionSet
@@ -167,7 +167,7 @@ func executeStep(
 
 			// if the target does not currently ask for id we need to add it
 			addID := true
-			for _, selection := range selectedFields(target) {
+			for _, selection := range graphql.SelectedFields(target) {
 				if selection.Name == "id" {
 					addID = false
 					break
@@ -337,7 +337,7 @@ func executorFindInsertionPoints(targetPoints []string, selectionSet ast.Selecti
 		var foundSelection *ast.Field
 
 		// there should be a field in the root selection set that has the target point
-		for _, selection := range selectedFields(selectionSetRoot) {
+		for _, selection := range graphql.SelectedFields(selectionSetRoot) {
 			// if the selection has the right name we need to add it to the list
 			if selection.Alias == point || selection.Name == point {
 				foundSelection = selection

--- a/execute.go
+++ b/execute.go
@@ -234,6 +234,7 @@ func executeStep(
 		Variables:     variables,
 	}, &queryResult)
 	if err != nil {
+		log.Warn("Network Error: ", err)
 		errCh <- err
 		return
 	}

--- a/execute_test.go
+++ b/execute_test.go
@@ -503,9 +503,13 @@ func TestExecutor_threadsVariables(t *testing.T) {
 							},
 						},
 					},
-					QueryDocument: &ast.OperationDefinition{
-						Operation:           "Query",
-						VariableDefinitions: ast.VariableDefinitionList{fullVariableDefs[0]},
+					QueryDocument: &ast.QueryDocument{
+						Operations: ast.OperationList{
+							{
+								Operation:           "Query",
+								VariableDefinitions: ast.VariableDefinitionList{fullVariableDefs[0]},
+							},
+						},
 					},
 					QueryString: `hello`,
 					Variables:   Set{"hello": true},
@@ -515,7 +519,7 @@ func TestExecutor_threadsVariables(t *testing.T) {
 							// make sure that we got the right variable inputs
 							assert.Equal(t, map[string]interface{}{"hello": "world"}, input.Variables)
 							// and definitions
-							assert.Equal(t, ast.VariableDefinitionList{fullVariableDefs[0]}, input.QueryDocument.VariableDefinitions)
+							assert.Equal(t, ast.VariableDefinitionList{fullVariableDefs[0]}, input.QueryDocument.Operations[0].VariableDefinitions)
 							assert.Equal(t, "hello", input.Query)
 
 							return map[string]interface{}{"values": []string{"world"}}, nil

--- a/gateway.go
+++ b/gateway.go
@@ -172,20 +172,22 @@ func (m FieldURLMap) Concat(other FieldURLMap) FieldURLMap {
 }
 
 // RegisterURL adds a new location to the list of possible places to find the value for parent.field
-func (m FieldURLMap) RegisterURL(parent string, field string, location string) {
-	// compute the key for the field
-	key := m.keyFor(parent, field)
+func (m FieldURLMap) RegisterURL(parent string, field string, locations ...string) {
+	for _, location := range locations {
+		// compute the key for the field
+		key := m.keyFor(parent, field)
 
-	// look up the value in the map
-	_, exists := m[key]
+		// look up the value in the map
+		_, exists := m[key]
 
-	// if we haven't seen this key before
-	if !exists {
-		// create a new list
-		m[key] = []string{location}
-	} else {
-		// we've seen this key before
-		m[key] = append(m[key], location)
+		// if we haven't seen this key before
+		if !exists {
+			// create a new list
+			m[key] = []string{location}
+		} else {
+			// we've seen this key before
+			m[key] = append(m[key], location)
+		}
 	}
 }
 

--- a/graphql/language.go
+++ b/graphql/language.go
@@ -1,0 +1,194 @@
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/vektah/gqlparser/ast"
+)
+
+// CollectedField is a representations of a field with the list of selection sets that
+// must be merged under that field.
+type CollectedField struct {
+	*ast.Field
+	NestedSelections []ast.SelectionSet
+}
+
+// CollectedFieldList is a list of CollectedField with utilities for retrieving them
+type CollectedFieldList []*CollectedField
+
+func (c *CollectedFieldList) GetOrCreateForAlias(alias string, creator func() *CollectedField) *CollectedField {
+	// look for the field with the given alias
+	for _, field := range *c {
+		if field.Alias == alias {
+			return field
+		}
+	}
+
+	// if we didn't find a field with the chosen alias
+	new := creator()
+
+	// add the new field to the list
+	*c = append(*c, new)
+
+	return new
+}
+
+// ApplyFragments takes a list of selections and merges them into one, embedding any fragments it
+// runs into along the way
+func ApplyFragments(selectionSet ast.SelectionSet, fragmentDefs ast.FragmentDefinitionList) (ast.SelectionSet, error) {
+	// build up a list of selection sets
+	final := ast.SelectionSet{}
+
+	// look for all of the collected fields
+	CollectedFields, err := collectFields([]ast.SelectionSet{selectionSet}, fragmentDefs)
+	if err != nil {
+		return nil, err
+	}
+
+	// the final result of collecting fields should have a single selection in its selection set
+	// which should be a selection for the same field referenced by collected.Field
+	for _, collected := range *CollectedFields {
+		final = append(final, collected.Field)
+	}
+
+	return final, nil
+}
+
+func collectFields(sources []ast.SelectionSet, fragments ast.FragmentDefinitionList) (*CollectedFieldList, error) {
+	// a way to look up field definitions and the list of selections we need under that field
+	selectedFields := &CollectedFieldList{}
+
+	// each selection set we have to merge can contribute to selections for each field
+	for _, selectionSet := range sources {
+		for _, selection := range selectionSet {
+			// a selection can be one of 3 things: a field, a fragment reference, or an inline fragment
+			switch selection := selection.(type) {
+
+			// a selection could either have a collected field or a real one. either way, we need to add the selection
+			// set to the entry in the map
+			case *ast.Field, *CollectedField:
+				var selectedField *ast.Field
+				if field, ok := selection.(*ast.Field); ok {
+					selectedField = field
+				} else if collected, ok := selection.(*CollectedField); ok {
+					selectedField = collected.Field
+				}
+
+				// look up the entry in the field list for this field
+				collected := selectedFields.GetOrCreateForAlias(selectedField.Alias, func() *CollectedField {
+					return &CollectedField{Field: selectedField}
+				})
+
+				// add the fields selection set to the list
+				collected.NestedSelections = append(collected.NestedSelections, selectedField.SelectionSet)
+
+			// fragment selections need to be unwrapped and added to the final selection
+			case *ast.InlineFragment, *ast.FragmentSpread:
+				var selectionSet ast.SelectionSet
+
+				// inline fragments
+				if inlineFragment, ok := selection.(*ast.InlineFragment); ok {
+					selectionSet = inlineFragment.SelectionSet
+
+					// fragment spread
+				} else if fragment, ok := selection.(*ast.FragmentSpread); ok {
+					// grab the definition for the fragment
+					definition := fragments.ForName(fragment.Name)
+					if definition == nil {
+						// this shouldn't happen since validation has already ran
+						return nil, fmt.Errorf("Could not find fragment definition: %s", fragment.Name)
+					}
+
+					selectionSet = definition.SelectionSet
+				}
+
+				// fields underneath the inline fragment could be fragments themselves
+				fields, err := collectFields([]ast.SelectionSet{selectionSet}, fragments)
+				if err != nil {
+					return nil, err
+				}
+
+				// each field in the inline fragment needs to be added to the selection
+				for _, fragmentSelection := range *fields {
+					// add the selection from the field to our accumulator
+					collected := selectedFields.GetOrCreateForAlias(fragmentSelection.Alias, func() *CollectedField {
+						return fragmentSelection
+					})
+
+					// add the fragment selection set to the list of selections for the field
+					collected.NestedSelections = append(collected.NestedSelections, fragmentSelection.SelectionSet)
+				}
+			}
+		}
+	}
+
+	// each selected field needs to be merged into a single selection set
+	for _, collected := range *selectedFields {
+		// compute the new selection set for this field
+		merged, err := collectFields(collected.NestedSelections, fragments)
+		if err != nil {
+			return nil, err
+		}
+
+		// if there are selections for the field we need to turn them into a selection set
+		selectionSet := ast.SelectionSet{}
+		for _, selection := range *merged {
+			selectionSet = append(selectionSet, selection)
+		}
+
+		// save this selection set over the nested one
+		collected.SelectionSet = selectionSet
+	}
+
+	// we're done
+	return selectedFields, nil
+}
+
+func SelectedFields(source ast.SelectionSet) []*ast.Field {
+	// build up a list of fields
+	fields := []*ast.Field{}
+
+	// each source could contribute fields to this
+	for _, selection := range source {
+		// if we are selecting a field
+		switch selection := selection.(type) {
+		case *ast.Field:
+			fields = append(fields, selection)
+		case *CollectedField:
+			fields = append(fields, selection.Field)
+		}
+	}
+
+	// we're done
+	return fields
+}
+
+// ExtractVariables takes a list of arguments and returns a list of every variable used
+func ExtractVariables(args ast.ArgumentList) []string {
+	// the list of variables
+	variables := []string{}
+
+	// each argument could contain variables
+	for _, arg := range args {
+		extractVariablesFromValues(&variables, arg.Value)
+	}
+
+	// return the list
+	return variables
+}
+
+func extractVariablesFromValues(accumulator *[]string, value *ast.Value) {
+	// we have to look out for a few different kinds of values
+	switch value.Kind {
+	// if the value is a reference to a variable
+	case ast.Variable:
+		// add the ference to the list
+		*accumulator = append(*accumulator, value.Raw)
+	// the value could be a list
+	case ast.ListValue, ast.ObjectValue:
+		// each entry in the list or object could contribute a variable
+		for _, child := range value.Children {
+			extractVariablesFromValues(accumulator, child.Value)
+		}
+	}
+}

--- a/graphql/language_test.go
+++ b/graphql/language_test.go
@@ -1,0 +1,303 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/ast"
+)
+
+func TestApplyFragments_mergesFragments(t *testing.T) {
+	// a selection set representing
+	// {
+	//      birthday
+	// 		... on User {
+	// 			firstName
+	//			lastName
+	// 			friends {
+	// 				firstName
+	// 			}
+	// 		}
+	//      ...SecondFragment
+	// 	}
+	//
+	// 	fragment SecondFragment on User {
+	// 		lastName
+	// 		friends {
+	// 			lastName
+	//			friends {
+	//				lastName
+	//			}
+	// 		}
+	// 	}
+	//
+	//
+	// should be flattened into
+	// {
+	//		birthday
+	// 		firstName
+	// 		lastName
+	// 		friends {
+	// 			firstName
+	// 			lastName
+	//			friends {
+	//				lastName
+	//			}
+	// 		}
+	// }
+	selectionSet := ast.SelectionSet{
+		&ast.Field{
+			Name:  "birthday",
+			Alias: "birthday",
+			Definition: &ast.FieldDefinition{
+				Type: ast.NamedType("DateTime", &ast.Position{}),
+			},
+		},
+		&ast.FragmentSpread{
+			Name: "SecondFragment",
+		},
+		&ast.InlineFragment{
+			TypeCondition: "User",
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{
+					Name:  "lastName",
+					Alias: "lastName",
+					Definition: &ast.FieldDefinition{
+						Type: ast.NamedType("String", &ast.Position{}),
+					},
+				},
+				&ast.Field{
+					Name:  "firstName",
+					Alias: "firstName",
+					Definition: &ast.FieldDefinition{
+						Type: ast.NamedType("String", &ast.Position{}),
+					},
+				},
+				&ast.Field{
+					Name:  "friends",
+					Alias: "friends",
+					Definition: &ast.FieldDefinition{
+						Type: ast.ListType(ast.NamedType("User", &ast.Position{}), &ast.Position{}),
+					},
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name:  "firstName",
+							Alias: "firstName",
+							Definition: &ast.FieldDefinition{
+								Type: ast.NamedType("String", &ast.Position{}),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fragmentDefinition := ast.FragmentDefinitionList{
+		&ast.FragmentDefinition{
+			Name: "SecondFragment",
+			SelectionSet: ast.SelectionSet{
+				&ast.Field{
+					Name:  "lastName",
+					Alias: "lastName",
+					Definition: &ast.FieldDefinition{
+						Type: ast.NamedType("String", &ast.Position{}),
+					},
+				},
+				&ast.Field{
+					Name:  "friends",
+					Alias: "friends",
+					Definition: &ast.FieldDefinition{
+						Type: ast.ListType(ast.NamedType("User", &ast.Position{}), &ast.Position{}),
+					},
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name:  "lastName",
+							Alias: "lastName",
+							Definition: &ast.FieldDefinition{
+								Type: ast.NamedType("String", &ast.Position{}),
+							},
+						},
+						&ast.Field{
+							Name:  "friends",
+							Alias: "friends",
+							Definition: &ast.FieldDefinition{
+								Type: ast.ListType(ast.NamedType("User", &ast.Position{}), &ast.Position{}),
+							},
+							SelectionSet: ast.SelectionSet{
+								&ast.Field{
+									Name:  "lastName",
+									Alias: "lastName",
+									Definition: &ast.FieldDefinition{
+										Type: ast.NamedType("String", &ast.Position{}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// should be flattened into
+	// {
+	//		birthday
+	// 		firstName
+	// 		lastName
+	// 		friends {
+	// 			firstName
+	// 			lastName
+	//			friends {
+	//				lastName
+	//			}
+	// 		}
+	// }
+
+	// flatten the selection
+	finalSelection, err := ApplyFragments(selectionSet, fragmentDefinition)
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	fields := SelectedFields(finalSelection)
+
+	// make sure there are 4 fields at the root of the selection
+	if len(fields) != 4 {
+		t.Errorf("Encountered the incorrect number of selections: %v", len(fields))
+		return
+	}
+
+	// get the selection set for birthday
+	var birthdaySelection *ast.Field
+	var firstNameSelection *ast.Field
+	var lastNameSelection *ast.Field
+	var friendsSelection *ast.Field
+
+	for _, selection := range fields {
+		switch selection.Alias {
+		case "birthday":
+			birthdaySelection = selection
+		case "firstName":
+			firstNameSelection = selection
+		case "lastName":
+			lastNameSelection = selection
+		case "friends":
+			friendsSelection = selection
+		}
+	}
+
+	// make sure we got each definition
+	assert.NotNil(t, birthdaySelection)
+	assert.NotNil(t, firstNameSelection)
+	assert.NotNil(t, lastNameSelection)
+	assert.NotNil(t, friendsSelection)
+
+	// make sure there are 3 selections under friends (firstName, lastName, and friends)
+	if len(friendsSelection.SelectionSet) != 3 {
+		t.Errorf("Encountered the wrong number of selections under .friends: len = %v)", len(friendsSelection.SelectionSet))
+		for _, selection := range friendsSelection.SelectionSet {
+			field, _ := selection.(*CollectedField)
+			t.Errorf("    %s", field.Name)
+		}
+		return
+	}
+}
+
+func TestExtractVariables(t *testing.T) {
+	table := []struct {
+		Name      string
+		Arguments ast.ArgumentList
+		Variables []string
+	}{
+		//  user(id: $id, name:$name) should extract ["id", "name"]
+		{
+			Name:      "Top Level arguments",
+			Variables: []string{"id", "name"},
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name: "id",
+					Value: &ast.Value{
+						Kind: ast.Variable,
+						Raw:  "id",
+					},
+				},
+				&ast.Argument{
+					Name: "name",
+					Value: &ast.Value{
+						Kind: ast.Variable,
+						Raw:  "name",
+					},
+				},
+			},
+		},
+		//  catPhotos(categories: [$a, "foo", $b]) should extract ["a", "b"]
+		{
+			Name:      "List nested arguments",
+			Variables: []string{"a", "b"},
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name: "category",
+					Value: &ast.Value{
+						Kind: ast.ListValue,
+						Children: ast.ChildValueList{
+							&ast.ChildValue{
+								Value: &ast.Value{
+									Kind: ast.Variable,
+									Raw:  "a",
+								},
+							},
+							&ast.ChildValue{
+								Value: &ast.Value{
+									Kind: ast.StringValue,
+									Raw:  "foo",
+								},
+							},
+							&ast.ChildValue{
+								Value: &ast.Value{
+									Kind: ast.Variable,
+									Raw:  "b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		//  users(favoriteMovieFilter: {category: $targetCategory, rating: $targetRating}) should extract ["targetCategory", "targetRating"]
+		{
+			Name:      "Object nested arguments",
+			Variables: []string{"targetCategory", "targetRating"},
+			Arguments: ast.ArgumentList{
+				&ast.Argument{
+					Name: "favoriteMovieFilter",
+					Value: &ast.Value{
+						Kind: ast.ObjectValue,
+						Children: ast.ChildValueList{
+							&ast.ChildValue{
+								Name: "category",
+								Value: &ast.Value{
+									Kind: ast.Variable,
+									Raw:  "targetCategory",
+								},
+							},
+							&ast.ChildValue{
+								Name: "rating",
+								Value: &ast.Value{
+									Kind: ast.Variable,
+									Raw:  "targetRating",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, row := range table {
+		t.Run(row.Name, func(t *testing.T) {
+			assert.Equal(t, row.Variables, ExtractVariables(row.Arguments))
+		})
+	}
+}

--- a/graphql/printer.go
+++ b/graphql/printer.go
@@ -11,7 +11,10 @@ import (
 )
 
 // PrintQuery creates a string representation of an operation
-func PrintQuery(operation *ast.OperationDefinition) (string, error) {
+func PrintQuery(document *ast.QueryDocument) (string, error) {
+	// grab the first operation in the document
+	operation := document.Operations[0]
+
 	// in order to print we are going to turn the vektah package Operation into the graphql-go ast node
 	selectionSet, err := printerConvertSelectionSet(operation.SelectionSet)
 	if err != nil {

--- a/graphql/printer.go
+++ b/graphql/printer.go
@@ -49,16 +49,6 @@ func PrintQuery(document *ast.QueryDocument) (string, error) {
 
 	// if we have fragment definitions to add
 	if len(document.Fragments) > 0 {
-		// type FragmentDefinition struct {
-		// 	Kind                string
-		// 	Loc                 *Location
-		// 	Operation           string
-		// 	Name                *Name
-		// 	VariableDefinitions []*VariableDefinition
-		// 	TypeCondition       *Named
-		// 	Directives          []*Directive
-		// 	SelectionSet        *SelectionSet
-		// }
 		for _, defn := range document.Fragments {
 			selectionSet, err := printerConvertSelectionSet(defn.SelectionSet)
 			if err != nil {

--- a/graphql/printer_test.go
+++ b/graphql/printer_test.go
@@ -148,24 +148,61 @@ func TestPrintQuery(t *testing.T) {
 }
 `,
 			&ast.QueryDocument{
-				Operations: ast.OperationList{&ast.OperationDefinition{
-					Operation: ast.Query,
-					SelectionSet: ast.SelectionSet{
-						&ast.InlineFragment{
-							TypeCondition: "Foo",
-							SelectionSet: ast.SelectionSet{
-								&ast.Field{
-									Name: "hello",
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Query,
+						SelectionSet: ast.SelectionSet{
+							&ast.InlineFragment{
+								TypeCondition: "Foo",
+								SelectionSet: ast.SelectionSet{
+									&ast.Field{
+										Name: "hello",
+									},
 								},
 							},
 						},
 					},
 				},
+			},
+		},
+		// fragments
+		{
+			`{
+  ...Foo
+}
+
+fragment Foo on User {
+  firstName
+}
+`,
+			&ast.QueryDocument{
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Query,
+						SelectionSet: ast.SelectionSet{
+							&ast.FragmentSpread{
+								Name: "Foo",
+							},
+						},
+					},
+				},
+				Fragments: ast.FragmentDefinitionList{
+					&ast.FragmentDefinition{
+						Name: "Foo",
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name: "firstName",
+								Definition: &ast.FieldDefinition{
+									Type: ast.NamedType("String", &ast.Position{}),
+								},
+							},
+						},
+						TypeCondition: "User",
+					},
 				},
 			},
 		},
 		// alias
-
 		{
 			`{
   bar: hello

--- a/graphql/printer_test.go
+++ b/graphql/printer_test.go
@@ -10,7 +10,7 @@ import (
 func TestPrintQuery(t *testing.T) {
 	table := []struct {
 		expected string
-		query    *ast.OperationDefinition
+		query    *ast.QueryDocument
 	}{
 		// single root field
 		{
@@ -18,11 +18,15 @@ func TestPrintQuery(t *testing.T) {
   hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Query,
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name: "hello",
+							},
+						},
 					},
 				},
 			},
@@ -33,17 +37,21 @@ func TestPrintQuery(t *testing.T) {
   hello(foo: $foo)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							&ast.Argument{
-								Name: "foo",
-								Value: &ast.Value{
-									Kind: ast.Variable,
-									Raw:  "foo",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Query,
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name: "hello",
+								Arguments: ast.ArgumentList{
+									&ast.Argument{
+										Name: "foo",
+										Value: &ast.Value{
+											Kind: ast.Variable,
+											Raw:  "foo",
+										},
+									},
 								},
 							},
 						},
@@ -57,26 +65,29 @@ func TestPrintQuery(t *testing.T) {
   hello @foo(bar: "baz")
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Directives: ast.DirectiveList{
-							&ast.Directive{
-								Name: "foo",
-								Arguments: ast.ArgumentList{
-									&ast.Argument{
-										Name: "bar",
-										Value: &ast.Value{
-											Kind: ast.StringValue,
-											Raw:  "baz",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Directives: ast.DirectiveList{
+								&ast.Directive{
+									Name: "foo",
+									Arguments: ast.ArgumentList{
+										&ast.Argument{
+											Name: "bar",
+											Value: &ast.Value{
+												Kind: ast.StringValue,
+												Raw:  "baz",
+											},
 										},
 									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -87,14 +98,18 @@ func TestPrintQuery(t *testing.T) {
   goodbye
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-					},
-					&ast.Field{
-						Name: "goodbye",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Query,
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name: "hello",
+							},
+							&ast.Field{
+								Name: "goodbye",
+							},
+						},
 					},
 				},
 			},
@@ -107,17 +122,20 @@ func TestPrintQuery(t *testing.T) {
   }
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						SelectionSet: ast.SelectionSet{
-							&ast.Field{
-								Name: "world",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							SelectionSet: ast.SelectionSet{
+								&ast.Field{
+									Name: "world",
+								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -129,17 +147,20 @@ func TestPrintQuery(t *testing.T) {
   }
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.InlineFragment{
-						TypeCondition: "Foo",
-						SelectionSet: ast.SelectionSet{
-							&ast.Field{
-								Name: "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.InlineFragment{
+							TypeCondition: "Foo",
+							SelectionSet: ast.SelectionSet{
+								&ast.Field{
+									Name: "hello",
+								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -150,13 +171,16 @@ func TestPrintQuery(t *testing.T) {
   bar: hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name:  "hello",
-						Alias: "bar",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name:  "hello",
+							Alias: "bar",
+						},
 					},
+				},
 				},
 			},
 		},
@@ -166,21 +190,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: "world")
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.StringValue,
-									Raw:  "world",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.StringValue,
+										Raw:  "world",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -190,21 +217,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: 1)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.IntValue,
-									Raw:  "1",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.IntValue,
+										Raw:  "1",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -214,21 +244,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: true)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.BooleanValue,
-									Raw:  "true",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.BooleanValue,
+										Raw:  "true",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -238,21 +271,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: $hello)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.IntValue,
-									Raw:  "$hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.IntValue,
+										Raw:  "$hello",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -262,20 +298,23 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: null)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.NullValue,
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.NullValue,
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -285,21 +324,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: 1.1)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.FloatValue,
-									Raw:  "1.1",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.FloatValue,
+										Raw:  "1.1",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -309,21 +351,24 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: Hello)
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.EnumValue,
-									Raw:  "Hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.EnumValue,
+										Raw:  "Hello",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -333,27 +378,29 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: ["hello", 1])
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.ListValue,
-									Children: ast.ChildValueList{
-										{
-											Value: &ast.Value{
-												Kind: ast.StringValue,
-												Raw:  "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.ListValue,
+										Children: ast.ChildValueList{
+											{
+												Value: &ast.Value{
+													Kind: ast.StringValue,
+													Raw:  "hello",
+												},
 											},
-										},
-										{
-											Value: &ast.Value{
-												Kind: ast.IntValue,
-												Raw:  "1",
+											{
+												Value: &ast.Value{
+													Kind: ast.IntValue,
+													Raw:  "1",
+												},
 											},
 										},
 									},
@@ -361,6 +408,7 @@ func TestPrintQuery(t *testing.T) {
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -370,29 +418,31 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: {hello: "hello", goodbye: 1})
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.ObjectValue,
-									Children: ast.ChildValueList{
-										{
-											Name: "hello",
-											Value: &ast.Value{
-												Kind: ast.StringValue,
-												Raw:  "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.ObjectValue,
+										Children: ast.ChildValueList{
+											{
+												Name: "hello",
+												Value: &ast.Value{
+													Kind: ast.StringValue,
+													Raw:  "hello",
+												},
 											},
-										},
-										{
-											Name: "goodbye",
-											Value: &ast.Value{
-												Kind: ast.IntValue,
-												Raw:  "1",
+											{
+												Name: "goodbye",
+												Value: &ast.Value{
+													Kind: ast.IntValue,
+													Raw:  "1",
+												},
 											},
 										},
 									},
@@ -400,6 +450,7 @@ func TestPrintQuery(t *testing.T) {
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -409,28 +460,31 @@ func TestPrintQuery(t *testing.T) {
   hello(hello: "world", goodbye: "moon")
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-						Arguments: ast.ArgumentList{
-							{
-								Name: "hello",
-								Value: &ast.Value{
-									Kind: ast.StringValue,
-									Raw:  "world",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+							Arguments: ast.ArgumentList{
+								{
+									Name: "hello",
+									Value: &ast.Value{
+										Kind: ast.StringValue,
+										Raw:  "world",
+									},
 								},
-							},
-							{
-								Name: "goodbye",
-								Value: &ast.Value{
-									Kind: ast.StringValue,
-									Raw:  "moon",
+								{
+									Name: "goodbye",
+									Value: &ast.Value{
+										Kind: ast.StringValue,
+										Raw:  "moon",
+									},
 								},
 							},
 						},
 					},
+				},
 				},
 			},
 		},
@@ -440,21 +494,24 @@ func TestPrintQuery(t *testing.T) {
   hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-					},
-				},
-				VariableDefinitions: ast.VariableDefinitionList{
-					&ast.VariableDefinition{
-						Variable: "id",
-						Type: &ast.Type{
-							NamedType: "ID",
-							NonNull:   true,
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
 						},
 					},
+					VariableDefinitions: ast.VariableDefinitionList{
+						&ast.VariableDefinition{
+							Variable: "id",
+							Type: &ast.Type{
+								NamedType: "ID",
+								NonNull:   true,
+							},
+						},
+					},
+				},
 				},
 			},
 		},
@@ -464,22 +521,25 @@ func TestPrintQuery(t *testing.T) {
   hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Query,
-				Name:      "foo",
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
-					},
-				},
-				VariableDefinitions: ast.VariableDefinitionList{
-					&ast.VariableDefinition{
-						Variable: "id",
-						Type: &ast.Type{
-							NamedType: "ID",
-							NonNull:   true,
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Query,
+					Name:      "foo",
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
 						},
 					},
+					VariableDefinitions: ast.VariableDefinitionList{
+						&ast.VariableDefinition{
+							Variable: "id",
+							Type: &ast.Type{
+								NamedType: "ID",
+								NonNull:   true,
+							},
+						},
+					},
+				},
 				},
 			},
 		},
@@ -489,12 +549,15 @@ func TestPrintQuery(t *testing.T) {
   hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Mutation,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{&ast.OperationDefinition{
+					Operation: ast.Mutation,
+					SelectionSet: ast.SelectionSet{
+						&ast.Field{
+							Name: "hello",
+						},
 					},
+				},
 				},
 			},
 		},
@@ -504,11 +567,15 @@ func TestPrintQuery(t *testing.T) {
   hello
 }
 `,
-			&ast.OperationDefinition{
-				Operation: ast.Subscription,
-				SelectionSet: ast.SelectionSet{
-					&ast.Field{
-						Name: "hello",
+			&ast.QueryDocument{
+				Operations: ast.OperationList{
+					&ast.OperationDefinition{
+						Operation: ast.Subscription,
+						SelectionSet: ast.SelectionSet{
+							&ast.Field{
+								Name: "hello",
+							},
+						},
 					},
 				},
 			},

--- a/graphql/requests.go
+++ b/graphql/requests.go
@@ -24,7 +24,7 @@ type RemoteSchema struct {
 // QueryInput provides all of the information required to fire a query
 type QueryInput struct {
 	Query         string
-	QueryDocument *ast.OperationDefinition
+	QueryDocument *ast.QueryDocument
 	OperationName string
 	Variables     map[string]interface{}
 }

--- a/logging.go
+++ b/logging.go
@@ -69,7 +69,7 @@ func (l *Logger) QueryPlanStep(step *QueryPlanStep) {
 		"insertion point": step.InsertionPoint,
 	}).Info(step.ParentType)
 
-	l.SelectionSet(step.SelectionSet)
+	log.Info(l.FormatSelectionSet(step.SelectionSet))
 }
 
 func (l *Logger) indentPrefix(level int) string {
@@ -109,11 +109,11 @@ func (l *Logger) selection(level int, selectionSet ast.SelectionSet) string {
 	return acc
 }
 
-// SelectionSet logs a selection set on a single line
-func (l *Logger) SelectionSet(selection ast.SelectionSet) string {
+// FormatSelectionSet returns a pretty printed version of a selection set
+func (l *Logger) FormatSelectionSet(selection ast.SelectionSet) string {
 	acc := "{"
 
-	insides := l.selection(1, selection)
+	insides := l.selection(0, selection)
 
 	if strings.TrimSpace(insides) != "" {
 		acc += insides + "\n}"
@@ -130,7 +130,7 @@ func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
 
 	// only log the warning severity or above.
-	entry.SetLevel(logrus.DebugLevel)
+	entry.SetLevel(logrus.WarnLevel)
 
 	// configure the formatter
 	entry.SetFormatter(&logrus.TextFormatter{

--- a/logging.go
+++ b/logging.go
@@ -83,16 +83,19 @@ func (l *Logger) indentPrefix(level int) string {
 }
 
 func (l *Logger) selection(level int, selectionSet ast.SelectionSet) string {
-	acc := l.indentPrefix(level)
+	acc := ""
 
 	for _, selection := range selectionSet {
+		acc += l.indentPrefix(level + 1)
 		switch selection := selection.(type) {
 		case *ast.Field:
 			// add the field name
 			acc += selection.Name
 			if len(selection.SelectionSet) > 0 {
+				acc += " {"
 				// and any sub selection
 				acc += l.selection(level+1, selection.SelectionSet)
+				acc += l.indentPrefix(level+1) + "}"
 			}
 		case *ast.InlineFragment:
 			// print the fragment name
@@ -130,7 +133,7 @@ func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
 
 	// only log the warning severity or above.
-	entry.SetLevel(logrus.WarnLevel)
+	entry.SetLevel(logrus.DebugLevel)
 
 	// configure the formatter
 	entry.SetFormatter(&logrus.TextFormatter{

--- a/logging.go
+++ b/logging.go
@@ -90,7 +90,7 @@ func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
 
 	// only log the warning severity or above.
-	entry.SetLevel(logrus.WarnLevel)
+	entry.SetLevel(logrus.DebugLevel)
 
 	// configure the formatter
 	entry.SetFormatter(&logrus.TextFormatter{

--- a/logging.go
+++ b/logging.go
@@ -136,7 +136,7 @@ func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
 
 	// only log the warning severity or above.
-	entry.SetLevel(logrus.DebugLevel)
+	entry.SetLevel(logrus.WarnLevel)
 
 	// configure the formatter
 	entry.SetFormatter(&logrus.TextFormatter{

--- a/logging.go
+++ b/logging.go
@@ -81,28 +81,31 @@ func (l *Logger) indentPrefix(level int) string {
 
 	return acc
 }
+func (l *Logger) selectionSelectionSet(level int, selectionSet ast.SelectionSet) string {
+	acc := " {"
+	// and any sub selection
+	acc += l.selection(level+1, selectionSet)
+	acc += l.indentPrefix(level) + "}"
+
+	return acc
+}
 
 func (l *Logger) selection(level int, selectionSet ast.SelectionSet) string {
 	acc := ""
 
 	for _, selection := range selectionSet {
-		acc += l.indentPrefix(level + 1)
+		acc += l.indentPrefix(level)
 		switch selection := selection.(type) {
 		case *ast.Field:
 			// add the field name
 			acc += selection.Name
 			if len(selection.SelectionSet) > 0 {
-				acc += " {"
-				// and any sub selection
-				acc += l.selection(level+1, selection.SelectionSet)
-				acc += l.indentPrefix(level+1) + "}"
+				acc += l.selectionSelectionSet(level, selection.SelectionSet)
 			}
 		case *ast.InlineFragment:
 			// print the fragment name
-			acc += fmt.Sprintf("... on %v {", selection.TypeCondition)
-			// and any sub selection
-			acc += l.selection(level+1, selection.SelectionSet)
-			acc += l.indentPrefix(level) + "}"
+			acc += fmt.Sprintf("... on %v", selection.TypeCondition) +
+				l.selectionSelectionSet(level, selection.SelectionSet)
 		case *ast.FragmentSpread:
 			// print the fragment name
 			acc += "..." + selection.Name

--- a/logging.go
+++ b/logging.go
@@ -90,7 +90,7 @@ func newLogEntry() *logrus.Entry {
 	entry := logrus.New()
 
 	// only log the warning severity or above.
-	entry.SetLevel(logrus.DebugLevel)
+	entry.SetLevel(logrus.WarnLevel)
 
 	// configure the formatter
 	entry.SetFormatter(&logrus.TextFormatter{

--- a/logging.go
+++ b/logging.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/vektah/gqlparser/ast"
+
+	"github.com/alecaivazis/graphql-gateway/graphql"
 )
 
 // Logger handles the logging in the gateway library
@@ -76,7 +78,7 @@ func logPlanStep(level int, selectionSet ast.SelectionSet) {
 		prefix += "    "
 	}
 	prefix += "|- "
-	for _, selection := range selectedFields(selectionSet) {
+	for _, selection := range graphql.SelectedFields(selectionSet) {
 		log.Info(prefix, selection.Name)
 		logPlanStep(level+1, selection.SelectionSet)
 	}

--- a/plan.go
+++ b/plan.go
@@ -741,7 +741,7 @@ func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, 
 
 		// we want the operation to have the equivalent of
 		// {
-		//	 	node(id: parentID) {
+		//	 	node(id: $id) {
 		//	 		... on parentType {
 		//	 			selection
 		//	 		}
@@ -768,6 +768,7 @@ func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, 
 			},
 		}
 
+		// if the original query didn't have an id arg we need to add one
 		if variables.ForName("id") == nil {
 			operation.VariableDefinitions = append(operation.VariableDefinitions, &ast.VariableDefinition{
 				Variable: "id",

--- a/plan.go
+++ b/plan.go
@@ -350,7 +350,6 @@ FieldLoop:
 
 			// for each bundle under a fragment
 			for location, selectionSet := range fragmentLocations {
-				fmt.Println("Spawning sibling handler for fragment", selection.Name, "@", location, log.FormatSelectionSet(selectionSet))
 				// add the fragment spread to the selection set for this location
 				locationFields[location] = append(locationFields[location], &ast.FragmentSpread{
 					Name:       selection.Name,
@@ -457,7 +456,6 @@ FieldLoop:
 					}
 
 					defn := config.step.FragmentDefinitions.ForName(wrap.Name)
-					fmt.Println("Wrapping in fragment spread", defn)
 
 					locationFragments[location] = append(locationFragments[location], &ast.FragmentDefinition{
 						Name:          wrap.Name,
@@ -500,7 +498,7 @@ FieldLoop:
 
 		// since we're adding another step we need to wait for at least one more goroutine to finish processing
 		config.stepWg.Add(1)
-		fmt.Println("Spawning sibling", log.FormatSelectionSet(selectionSet))
+
 		// add the new step
 		config.stepCh <- &newQueryPlanStepPayload{
 			Plan:           config.plan,

--- a/plan.go
+++ b/plan.go
@@ -290,7 +290,7 @@ func (p *MinQueriesPlanner) preparePlanQueries(plan *QueryPlan, step *QueryPlanS
 			// look for the selection with that name
 			for _, selection := range selectedFields(accumulator) {
 				// if we still have to walk down the selection but we found the right branch
-				if selection.Name == point {
+				if selection.Alias == point {
 					accumulator = selection.SelectionSet
 					targetField = selection
 					foundSelection = true

--- a/plan.go
+++ b/plan.go
@@ -455,8 +455,6 @@ FieldLoop:
 						Directives: wrap.Directives,
 					}
 
-					defn := config.step.FragmentDefinitions.ForName(wrap.Name)
-
 					locationFragments[location] = append(locationFragments[location], &ast.FragmentDefinition{
 						Name:          wrap.Name,
 						TypeCondition: config.parentType,

--- a/plan.go
+++ b/plan.go
@@ -280,15 +280,26 @@ func (p *MinQueriesPlanner) preparePlanQueries(plan *QueryPlan, step *QueryPlanS
 		var targetField *ast.Field
 
 		// walk down the list of insertion points
-		for _, point := range nextStep.InsertionPoint {
+		for i := len(step.InsertionPoint); i < len(nextStep.InsertionPoint); i++ {
+			// the point we are looking for in the selection set
+			point := nextStep.InsertionPoint[i]
+
+			// wether we found the corresponding field or not
+			foundSelection := false
+
 			// look for the selection with that name
 			for _, selection := range selectedFields(accumulator) {
 				// if we still have to walk down the selection but we found the right branch
 				if selection.Name == point {
 					accumulator = selection.SelectionSet
 					targetField = selection
+					foundSelection = true
 					break
 				}
+			}
+
+			if !foundSelection {
+				return fmt.Errorf("Could not find selection for point: %s", point)
 			}
 		}
 

--- a/plan.go
+++ b/plan.go
@@ -528,7 +528,6 @@ FieldLoop:
 			// we have to walk down the fragments definition and keep adding to the selection sets and fragment definitions
 			// add it to the list
 			finalSelection = append(finalSelection, selection)
-			fmt.Println("Encountered fragment spread. Selection so far: ", finalSelection[0])
 
 			// grab the official definition for the fragment
 			defn := config.plan.FragmentDefinitions.ForName(selection.Name)

--- a/plan.go
+++ b/plan.go
@@ -19,7 +19,7 @@ type QueryPlanStep struct {
 	SelectionSet        ast.SelectionSet
 	InsertionPoint      []string
 	Then                []*QueryPlanStep
-	QueryDocument       *ast.OperationDefinition
+	QueryDocument       *ast.QueryDocument
 	QueryString         string
 	FragmentDefinitions ast.FragmentDefinitionList
 	Variables           Set
@@ -137,11 +137,12 @@ func (p *MinQueriesPlanner) generatePlans(query string, schema *ast.Schema, loca
 				select {
 				case payload := <-newSteps:
 					step := &QueryPlanStep{
-						Queryer:        p.GetQueryer(payload.Location, schema),
-						ParentType:     payload.ParentType,
-						SelectionSet:   ast.SelectionSet{},
-						InsertionPoint: payload.InsertionPoint,
-						Variables:      Set{},
+						Queryer:             p.GetQueryer(payload.Location, schema),
+						ParentType:          payload.ParentType,
+						SelectionSet:        ast.SelectionSet{},
+						InsertionPoint:      payload.InsertionPoint,
+						Variables:           Set{},
+						FragmentDefinitions: plan.FragmentDefinitions,
 					}
 
 					// if there is a parent to this query
@@ -158,7 +159,7 @@ func (p *MinQueriesPlanner) generatePlans(query string, schema *ast.Schema, loca
 
 					// log some stuffs
 					selectionNames := []string{}
-					for _, selection := range selectedFields(step.SelectionSet) {
+					for _, selection := range graphql.SelectedFields(step.SelectionSet) {
 						selectionNames = append(selectionNames, selection.Name)
 					}
 
@@ -205,7 +206,7 @@ func (p *MinQueriesPlanner) generatePlans(query string, schema *ast.Schema, loca
 					stepWg.Done()
 
 					log.Debug("Step selection set:")
-					for _, selection := range selectedFields(step.SelectionSet) {
+					for _, selection := range graphql.SelectedFields(step.SelectionSet) {
 						log.Debug(selection.Name)
 					}
 				}
@@ -263,7 +264,7 @@ func (p *MinQueriesPlanner) extractSelection(config *extractSelectionConfig) (as
 	// the selection set by the location.
 
 	locationFields := map[string]ast.SelectionSet{}
-	fragmentDefs := map[string]ast.FragmentDefinitionList{}
+	// fragmentDefs := map[string]ast.FragmentDefinitionList{}
 
 	// we have to pass over this list twice so we can place selections that can go in more than one place
 	fieldsLeft := []*ast.Field{}
@@ -312,6 +313,15 @@ func (p *MinQueriesPlanner) extractSelection(config *extractSelectionConfig) (as
 					fragmentLocations[fieldLocations[0]] = append(fragmentLocations[fieldLocations[0]], fragmentSelection)
 				}
 			}
+
+			// for each bundle under a fragment
+			for location := range fragmentLocations {
+				locationFields[location] = append(locationFields[location], &ast.FragmentSpread{
+					Name:       selection.Name,
+					Directives: selection.Directives,
+				})
+			}
+
 		case *ast.InlineFragment:
 			// we need to split the inline fragment into an inline fragment for each location that this cover
 			// and then add those inline fragments to the final selection
@@ -421,7 +431,7 @@ FieldLoop:
 			// the field is now safe to add to the parents selection set
 
 			// any variables that this field depends on need to be added to the steps list of variables
-			for _, variable := range plannerExtractVariables(selection.Arguments) {
+			for _, variable := range graphql.ExtractVariables(selection.Arguments) {
 				config.step.Variables.Add(variable)
 			}
 
@@ -433,7 +443,7 @@ FieldLoop:
 			finalSelection = append(finalSelection, selection)
 		}
 	}
-	fmt.Println(finalSelection)
+
 	// we should have added every field that needs to be added to this list
 	return finalSelection, nil
 }
@@ -473,7 +483,7 @@ func (p *MinQueriesPlanner) preparePlanQueries(plan *QueryPlan, step *QueryPlanS
 			foundSelection := false
 
 			// look for the selection with that name
-			for _, selection := range selectedFields(accumulator) {
+			for _, selection := range graphql.SelectedFields(accumulator) {
 				// if we still have to walk down the selection but we found the right branch
 				if selection.Alias == point {
 					accumulator = selection.SelectionSet
@@ -495,7 +505,7 @@ func (p *MinQueriesPlanner) preparePlanQueries(plan *QueryPlan, step *QueryPlanS
 
 		// if the target does not currently ask for id we need to add it
 		addID := true
-		for _, selection := range selectedFields(accumulator) {
+		for _, selection := range graphql.SelectedFields(accumulator) {
 			if selection.Name == "id" {
 				addID = false
 				break
@@ -522,7 +532,7 @@ func (p *MinQueriesPlanner) preparePlanQueries(plan *QueryPlan, step *QueryPlanS
 	}
 
 	// build up the query document
-	step.QueryDocument = plannerBuildQuery(step.ParentType, variableDefs, step.SelectionSet)
+	step.QueryDocument = plannerBuildQuery(step.ParentType, variableDefs, step.SelectionSet, step.FragmentDefinitions)
 
 	// we also need to turn the query into a string
 	queryString, err := graphql.PrintQuery(step.QueryDocument)
@@ -553,196 +563,11 @@ func (set Set) Remove(k string) {
 	delete(set, k)
 }
 
-// Includes returns wether or not the string is in the set
+// Has returns wether or not the string is in the set
 func (set Set) Has(k string) bool {
 	_, ok := set[k]
 
 	return ok
-}
-
-// collectedFields are representations of a field with the list of selection sets that
-// must be merged under that field.
-type collectedField struct {
-	*ast.Field
-	NestedSelections []ast.SelectionSet
-}
-
-type collectedFieldList []*collectedField
-
-func (c *collectedFieldList) GetOrCreateForAlias(alias string, creator func() *collectedField) *collectedField {
-	// look for the field with the given alias
-	for _, field := range *c {
-		if field.Alias == alias {
-			return field
-		}
-	}
-
-	// if we didn't find a field with the chosen alias
-	new := creator()
-
-	// add the new field to the list
-	*c = append(*c, new)
-
-	return new
-}
-
-// applyFragments takes a list of selections and merges them into one, embedding any fragments it
-// runs into along the way
-func plannerApplyFragments(selectionSet ast.SelectionSet, fragmentDefs ast.FragmentDefinitionList) (ast.SelectionSet, error) {
-	// build up a list of selection sets
-	final := ast.SelectionSet{}
-
-	// look for all of the collected fields
-	collectedFields, err := plannerCollectFields([]ast.SelectionSet{selectionSet}, fragmentDefs)
-	if err != nil {
-		return nil, err
-	}
-
-	// the final result of collecting fields should have a single selection in its selection set
-	// which should be a selection for the same field referenced by collected.Field
-	for _, collected := range *collectedFields {
-		final = append(final, collected.Field)
-	}
-
-	return final, nil
-}
-
-func plannerCollectFields(sources []ast.SelectionSet, fragments ast.FragmentDefinitionList) (*collectedFieldList, error) {
-	// a way to look up field definitions and the list of selections we need under that field
-	selectedFields := &collectedFieldList{}
-
-	// each selection set we have to merge can contribute to selections for each field
-	for _, selectionSet := range sources {
-		for _, selection := range selectionSet {
-			// a selection can be one of 3 things: a field, a fragment reference, or an inline fragment
-			switch selection := selection.(type) {
-
-			// a selection could either have a collected field or a real one. either way, we need to add the selection
-			// set to the entry in the map
-			case *ast.Field, *collectedField:
-				var selectedField *ast.Field
-				if field, ok := selection.(*ast.Field); ok {
-					selectedField = field
-				} else if collected, ok := selection.(*collectedField); ok {
-					selectedField = collected.Field
-				}
-
-				// look up the entry in the field list for this field
-				collected := selectedFields.GetOrCreateForAlias(selectedField.Alias, func() *collectedField {
-					return &collectedField{Field: selectedField}
-				})
-
-				// add the fields selection set to the list
-				collected.NestedSelections = append(collected.NestedSelections, selectedField.SelectionSet)
-
-			// fragment selections need to be unwrapped and added to the final selection
-			case *ast.InlineFragment, *ast.FragmentSpread:
-				var selectionSet ast.SelectionSet
-
-				// inline fragments
-				if inlineFragment, ok := selection.(*ast.InlineFragment); ok {
-					selectionSet = inlineFragment.SelectionSet
-
-					// fragment spread
-				} else if fragment, ok := selection.(*ast.FragmentSpread); ok {
-					// grab the definition for the fragment
-					definition := fragments.ForName(fragment.Name)
-					if definition == nil {
-						// this shouldn't happen since validation has already ran
-						return nil, fmt.Errorf("Could not find fragment definition: %s", fragment.Name)
-					}
-
-					selectionSet = definition.SelectionSet
-				}
-
-				// fields underneath the inline fragment could be fragments themselves
-				fields, err := plannerCollectFields([]ast.SelectionSet{selectionSet}, fragments)
-				if err != nil {
-					return nil, err
-				}
-
-				// each field in the inline fragment needs to be added to the selection
-				for _, fragmentSelection := range *fields {
-					// add the selection from the field to our accumulator
-					collected := selectedFields.GetOrCreateForAlias(fragmentSelection.Alias, func() *collectedField {
-						return fragmentSelection
-					})
-
-					// add the fragment selection set to the list of selections for the field
-					collected.NestedSelections = append(collected.NestedSelections, fragmentSelection.SelectionSet)
-				}
-			}
-		}
-	}
-
-	// each selected field needs to be merged into a single selection set
-	for _, collected := range *selectedFields {
-		// compute the new selection set for this field
-		merged, err := plannerCollectFields(collected.NestedSelections, fragments)
-		if err != nil {
-			return nil, err
-		}
-
-		// if there are selections for the field we need to turn them into a selection set
-		selectionSet := ast.SelectionSet{}
-		for _, selection := range *merged {
-			selectionSet = append(selectionSet, selection)
-		}
-
-		// save this selection set over the nested one
-		collected.SelectionSet = selectionSet
-	}
-
-	// we're done
-	return selectedFields, nil
-}
-
-func plannerExtractVariables(args ast.ArgumentList) []string {
-	// the list of variables
-	variables := []string{}
-
-	// each argument could contain variables
-	for _, arg := range args {
-		plannerExtractVariablesFromValues(&variables, arg.Value)
-	}
-
-	// return the list
-	return variables
-}
-
-func plannerExtractVariablesFromValues(accumulator *[]string, value *ast.Value) {
-	// we have to look out for a few different kinds of values
-	switch value.Kind {
-	// if the value is a reference to a variable
-	case ast.Variable:
-		// add the ference to the list
-		*accumulator = append(*accumulator, value.Raw)
-	// the value could be a list
-	case ast.ListValue, ast.ObjectValue:
-		// each entry in the list or object could contribute a variable
-		for _, child := range value.Children {
-			plannerExtractVariablesFromValues(accumulator, child.Value)
-		}
-	}
-}
-
-func selectedFields(source ast.SelectionSet) []*ast.Field {
-	// build up a list of fields
-	fields := []*ast.Field{}
-
-	// each source could contribute fields to this
-	for _, selection := range source {
-		// if we are selecting a field
-		switch selection := selection.(type) {
-		case *ast.Field:
-			fields = append(fields, selection)
-		case *collectedField:
-			fields = append(fields, selection.Field)
-		}
-	}
-
-	// we're done
-	return fields
 }
 
 // GetQueryer returns the queryer that should be used to resolve the plan
@@ -762,7 +587,7 @@ func (p *Planner) GetQueryer(url string, schema *ast.Schema) graphql.Queryer {
 	return graphql.NewNetworkQueryer(url)
 }
 
-func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet) *ast.OperationDefinition {
+func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, selectionSet ast.SelectionSet, fragmentDefinitions ast.FragmentDefinitionList) *ast.QueryDocument {
 	log.Debug("Querying ", parentType, " ")
 	// build up an operation for the query
 	operation := &ast.OperationDefinition{
@@ -814,10 +639,13 @@ func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, 
 			})
 		}
 	}
-	log.Debug("Build Query")
+	fmt.Println("Build Query with fragments", fragmentDefinitions)
 
 	// add the operation to a QueryDocument
-	return operation
+	return &ast.QueryDocument{
+		Operations: ast.OperationList{operation},
+		Fragments:  fragmentDefinitions,
+	}
 }
 
 // MockErrPlanner always returns the provided error. Useful in testing.

--- a/plan.go
+++ b/plan.go
@@ -639,7 +639,6 @@ func plannerBuildQuery(parentType string, variables ast.VariableDefinitionList, 
 			})
 		}
 	}
-	fmt.Println("Build Query with fragments", fragmentDefinitions)
 
 	// add the operation to a QueryDocument
 	return &ast.QueryDocument{

--- a/plan_test.go
+++ b/plan_test.go
@@ -875,7 +875,8 @@ func TestPlanQuery_stepVariables(t *testing.T) {
 	}
 }
 
-func TestPlanQuery_singleFragmentMultipleLocations(t *testing.T) { // the locations for the schema
+func TestPlanQuery_singleFragmentMultipleLocations(t *testing.T) {
+	// the locations for the schema
 	loc1 := "url1"
 	loc2 := "url2"
 
@@ -883,6 +884,7 @@ func TestPlanQuery_singleFragmentMultipleLocations(t *testing.T) { // the locati
 	locations := FieldURLMap{}
 	locations.RegisterURL("Query", "user", loc2)
 	locations.RegisterURL("User", "lastName", loc1)
+	locations.RegisterURL("User", "id", loc1, loc2)
 
 	schema, _ := graphql.LoadSchema(`
 		type User {

--- a/plan_test.go
+++ b/plan_test.go
@@ -516,7 +516,8 @@ func TestPreparePlanQueries(t *testing.T) {
 		InsertionPoint: []string{"followers", "users", "friends", "followers"},
 		SelectionSet: ast.SelectionSet{
 			&ast.Field{
-				Name: "firstName",
+				Name:  "firstName",
+				Alias: "firstName",
 				Definition: &ast.FieldDefinition{
 					Type: ast.NamedType("String", &ast.Position{}),
 				},
@@ -528,7 +529,8 @@ func TestPreparePlanQueries(t *testing.T) {
 		InsertionPoint: []string{"followers", "users", "friends"},
 		SelectionSet: ast.SelectionSet{
 			&ast.Field{
-				Name: "followers",
+				Name:  "followers",
+				Alias: "followers",
 				Definition: &ast.FieldDefinition{
 					Type: ast.NonNullListType(ast.NamedType("String", &ast.Position{}), &ast.Position{}),
 				},
@@ -542,19 +544,22 @@ func TestPreparePlanQueries(t *testing.T) {
 		InsertionPoint: []string{"followers"},
 		SelectionSet: ast.SelectionSet{
 			&ast.Field{
-				Name: "users",
+				Name:  "users",
+				Alias: "users",
 				Definition: &ast.FieldDefinition{
 					Type: ast.ListType(ast.NamedType("User", &ast.Position{}), &ast.Position{}),
 				},
 				SelectionSet: ast.SelectionSet{
 					&ast.Field{
-						Name: "friends",
+						Name:  "friends",
+						Alias: "friends",
 						Definition: &ast.FieldDefinition{
 							Type: ast.ListType(ast.NamedType("User", &ast.Position{}), &ast.Position{}),
 						},
 						SelectionSet: ast.SelectionSet{
 							&ast.Field{
-								Name: "lastName",
+								Name:  "lastName",
+								Alias: "lastName",
 								Definition: &ast.FieldDefinition{
 									Type: ast.NamedType("String", &ast.Position{}),
 								},
@@ -627,7 +632,7 @@ func TestPreparePlanQueries(t *testing.T) {
 		t.Errorf("Encountered incorrect number of fields under secondStep.followers: %v", len(selectedFields(childStep.SelectionSet)[0].SelectionSet))
 	}
 
-	fmt.Println(selectedFields(selectedFields(childStep.SelectionSet)[0].SelectionSet)[0].Name)
+	assert.Equal(t, "id", selectedFields(selectedFields(childStep.SelectionSet)[0].SelectionSet)[0].Name)
 }
 
 func TestExtractVariables(t *testing.T) {

--- a/plan_test.go
+++ b/plan_test.go
@@ -315,7 +315,6 @@ func TestPlanQuery_nestedInlineFragmentsSameLocation(t *testing.T) {
 		}
 	`)
 
-	// compute the plan for a query that just hits one service
 	plans, err := (&MinQueriesPlanner{}).Plan(`
 		query MyQuery {
 			... on Query {
@@ -381,7 +380,7 @@ func TestPlanQuery_nestedInlineFragmentsSameLocation(t *testing.T) {
 		return
 	}
 	loc1SubSelection, ok := loc1Selection.SelectionSet[0].(*ast.InlineFragment)
-	if !assert.True(t, ok) {
+	if !assert.True(t, ok, "first sub-selection in location 1 selection is not an inline fragment: \n%v", log.FormatSelectionSet(loc1Selection.SelectionSet)) {
 		return
 	}
 
@@ -403,10 +402,6 @@ func TestPlanQuery_nestedInlineFragmentsSameLocation(t *testing.T) {
 	// 			bar
 	// 		}
 	// }
-	if loc2Step.QueryDocument.Operations[0].Name != "MyQuery" {
-		t.Errorf("Encountered incorrect operation name for query. Expected MyQuery found %v", loc2Step.QueryDocument.Operations[0].Name)
-		return
-	}
 
 	if !assert.Len(t, loc2Step.SelectionSet, 1) {
 		return

--- a/plan_test.go
+++ b/plan_test.go
@@ -1058,32 +1058,10 @@ func TestPlannerBuildQuery_node(t *testing.T) {
 	assert.Equal(t, selection, fragment.SelectionSet)
 }
 
-func TestApplyFragments_skipAndIncludeDirectives(t *testing.T) {
-	t.Skip("Not yet implemented")
-}
-
-func TestApplyFragments_leavesUnionsAndInterfaces(t *testing.T) {
-	t.Skip("Not yet implemented")
-}
-
 func TestPlanQuery_multipleRootFields(t *testing.T) {
 	t.Skip("Not implemented")
 }
 
 func TestPlanQuery_mutationsInSeries(t *testing.T) {
-	t.Skip("Not implemented")
-}
-
-func TestPlanQuery_siblingFields(t *testing.T) {
-	t.Skip("Not implemented")
-}
-
-func TestPlanQuery_duplicateFieldsOnEither(t *testing.T) {
-	// make sure that if I have the same field defined on both schemas we dont create extraneous calls
-	t.Skip("Not implemented")
-}
-
-func TestPlanQuery_groupsConflictingFields(t *testing.T) {
-	// if I can find a field in 4 different services, look for the one I"m already going to
 	t.Skip("Not implemented")
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -87,7 +87,7 @@ func TestPlanQuery_includeFragmentsSameLocation(t *testing.T) {
 		return
 	}
 
-	if len(plans[0].RootStep.Then) == 0 {
+	if len(plans[0].RootStep.Then) != 1 {
 		t.Error("Could not find the step with fragment spread")
 		return
 	}
@@ -104,7 +104,7 @@ func TestPlanQuery_includeFragmentsSameLocation(t *testing.T) {
 	// there should be a single selection that is a spread of the fragment Foo
 	fragment, ok := root.SelectionSet[0].(*ast.FragmentSpread)
 	if !ok {
-		t.Error("Root selection was not a fragment spread")
+		t.Error("Root selection was not a fragment spread", root.SelectionSet[0])
 		return
 	}
 
@@ -112,7 +112,7 @@ func TestPlanQuery_includeFragmentsSameLocation(t *testing.T) {
 	assert.Equal(t, "Foo", fragment.Name)
 
 	// we need to make sure that the fragment definition matches expectation
-	fragmentDef := root.FragmentDefinitions.ForName("Foo")
+	fragmentDef := root.QueryDocument.Fragments.ForName("Foo")
 	if fragmentDef == nil {
 		t.Error("Could not find fragment definition for Foo")
 		return

--- a/schema.go
+++ b/schema.go
@@ -31,7 +31,6 @@ func (q *SchemaQueryer) Query(input *graphql.QueryInput, receiver interface{}) e
 	// wrap the schema in something capable of introspection
 	introspectionSchema := introspection.WrapSchema(q.Schema)
 
-	fmt.Println("Query Fragments -> ", input.QueryDocument.Fragments)
 	// for local stuff we don't care about fragment directives
 	querySelection, err := graphql.ApplyFragments(input.QueryDocument.Operations[0].SelectionSet, input.QueryDocument.Fragments)
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -31,8 +31,6 @@ func (q *SchemaQueryer) Query(input *graphql.QueryInput, receiver interface{}) e
 	// wrap the schema in something capable of introspection
 	introspectionSchema := introspection.WrapSchema(q.Schema)
 
-	fmt.Println("Fragments -> ", input.QueryDocument.Fragments)
-
 	// for local stuff we don't care about fragment directives
 	querySelection, err := graphql.ApplyFragments(input.QueryDocument.Operations[0].SelectionSet, input.QueryDocument.Fragments)
 	if err != nil {
@@ -88,12 +86,10 @@ func (q *SchemaQueryer) introspectSchema(schema *introspection.Schema, selection
 	result := map[string]interface{}{}
 
 	for _, field := range graphql.SelectedFields(selectionSet) {
-		fmt.Println(field.Name, field.Alias)
 		switch field.Alias {
 		case "types":
 			result[field.Alias] = q.introspectTypeSlice(schema.Types(), field.SelectionSet)
 		case "queryType":
-			fmt.Println("Looking for query type")
 			result[field.Alias] = q.introspectType(schema.QueryType(), field.SelectionSet)
 		case "mutationType":
 			result[field.Alias] = q.introspectType(schema.MutationType(), field.SelectionSet)

--- a/schema.go
+++ b/schema.go
@@ -31,6 +31,7 @@ func (q *SchemaQueryer) Query(input *graphql.QueryInput, receiver interface{}) e
 	// wrap the schema in something capable of introspection
 	introspectionSchema := introspection.WrapSchema(q.Schema)
 
+	fmt.Println("Query Fragments -> ", input.QueryDocument.Fragments)
 	// for local stuff we don't care about fragment directives
 	querySelection, err := graphql.ApplyFragments(input.QueryDocument.Operations[0].SelectionSet, input.QueryDocument.Fragments)
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -31,32 +31,37 @@ func (q *SchemaQueryer) Query(input *graphql.QueryInput, receiver interface{}) e
 	// wrap the schema in something capable of introspection
 	introspectionSchema := introspection.WrapSchema(q.Schema)
 
-	// each value selected contributes to the response
-	for _, selection := range input.QueryDocument.SelectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			if field.Name == "__schema" {
-				result[field.Alias] = q.introspectSchema(introspectionSchema, field.SelectionSet)
+	fmt.Println("Fragments -> ", input.QueryDocument.Fragments)
+
+	// for local stuff we don't care about fragment directives
+	querySelection, err := graphql.ApplyFragments(input.QueryDocument.Operations[0].SelectionSet, input.QueryDocument.Fragments)
+	if err != nil {
+		return err
+	}
+
+	for _, field := range graphql.SelectedFields(querySelection) {
+		if field.Name == "__schema" {
+			result[field.Alias] = q.introspectSchema(introspectionSchema, field.SelectionSet)
+		}
+		if field.Name == "__type" {
+			// there is a name argument to look up the type
+			name := field.Arguments.ForName("name").Value.Raw
+
+			// look for the type with the designated name
+			var introspectedType *introspection.Type
+			for _, schemaType := range introspectionSchema.Types() {
+				if *schemaType.Name() == name {
+					introspectedType = &schemaType
+					break
+				}
 			}
-			if field.Name == "__type" {
-				// there is a name argument to look up the type
-				name := field.Arguments.ForName("name").Value.Raw
 
-				// look for the type with the designated name
-				var introspectedType *introspection.Type
-				for _, schemaType := range introspectionSchema.Types() {
-					if *schemaType.Name() == name {
-						introspectedType = &schemaType
-						break
-					}
-				}
-
-				// if we couldn't find the type
-				if introspectedType == nil {
-					result[field.Alias] = nil
-				} else {
-					// we found the type so introspect it
-					result[field.Alias] = q.introspectType(introspectedType, field.SelectionSet)
-				}
+			// if we couldn't find the type
+			if introspectedType == nil {
+				result[field.Alias] = nil
+			} else {
+				// we found the type so introspect it
+				result[field.Alias] = q.introspectType(introspectedType, field.SelectionSet)
 			}
 		}
 	}
@@ -82,20 +87,20 @@ func (q *SchemaQueryer) introspectSchema(schema *introspection.Schema, selection
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			switch field.Alias {
-			case "types":
-				result[field.Alias] = q.introspectTypeSlice(schema.Types(), field.SelectionSet)
-			case "queryType":
-				result[field.Alias] = q.introspectType(schema.QueryType(), field.SelectionSet)
-			case "mutationType":
-				result[field.Alias] = q.introspectType(schema.MutationType(), field.SelectionSet)
-			case "subscriptionType":
-				result[field.Alias] = q.introspectType(schema.SubscriptionType(), field.SelectionSet)
-			case "directives":
-				result[field.Alias] = q.introspectDirectiveSlice(schema.Directives(), field.SelectionSet)
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		fmt.Println(field.Name, field.Alias)
+		switch field.Alias {
+		case "types":
+			result[field.Alias] = q.introspectTypeSlice(schema.Types(), field.SelectionSet)
+		case "queryType":
+			fmt.Println("Looking for query type")
+			result[field.Alias] = q.introspectType(schema.QueryType(), field.SelectionSet)
+		case "mutationType":
+			result[field.Alias] = q.introspectType(schema.MutationType(), field.SelectionSet)
+		case "subscriptionType":
+			result[field.Alias] = q.introspectType(schema.SubscriptionType(), field.SelectionSet)
+		case "directives":
+			result[field.Alias] = q.introspectDirectiveSlice(schema.Directives(), field.SelectionSet)
 		}
 	}
 
@@ -110,34 +115,32 @@ func (q *SchemaQueryer) introspectType(schemaType *introspection.Type, selection
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			// the default behavior is to ignore deprecated fields
-			includeDeprecated := false
-			if passedValue := field.Arguments.ForName("includeDeprecated"); passedValue != nil && passedValue.Value.Raw == "true" {
-				includeDeprecated = true
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		// the default behavior is to ignore deprecated fields
+		includeDeprecated := false
+		if passedValue := field.Arguments.ForName("includeDeprecated"); passedValue != nil && passedValue.Value.Raw == "true" {
+			includeDeprecated = true
+		}
 
-			switch field.Name {
-			case "kind":
-				result[field.Alias] = schemaType.Kind()
-			case "name":
-				result[field.Alias] = schemaType.Name()
-			case "description":
-				result[field.Alias] = schemaType.Description()
-			case "fields":
-				result[field.Alias] = q.introspectFieldSlice(schemaType.Fields(includeDeprecated), field.SelectionSet)
-			case "interfaces":
-				result[field.Alias] = q.introspectTypeSlice(schemaType.Interfaces(), field.SelectionSet)
-			case "possibleTypes":
-				result[field.Alias] = q.introspectTypeSlice(schemaType.PossibleTypes(), field.SelectionSet)
-			case "enumValues":
-				result[field.Alias] = q.introspectEnumValueSlice(schemaType.EnumValues(includeDeprecated), field.SelectionSet)
-			case "inputFields":
-				result[field.Alias] = q.introspectInputValueSlice(schemaType.InputFields(), field.SelectionSet)
-			case "ofType":
-				result[field.Alias] = q.introspectType(schemaType.OfType(), field.SelectionSet)
-			}
+		switch field.Name {
+		case "kind":
+			result[field.Alias] = schemaType.Kind()
+		case "name":
+			result[field.Alias] = schemaType.Name()
+		case "description":
+			result[field.Alias] = schemaType.Description()
+		case "fields":
+			result[field.Alias] = q.introspectFieldSlice(schemaType.Fields(includeDeprecated), field.SelectionSet)
+		case "interfaces":
+			result[field.Alias] = q.introspectTypeSlice(schemaType.Interfaces(), field.SelectionSet)
+		case "possibleTypes":
+			result[field.Alias] = q.introspectTypeSlice(schemaType.PossibleTypes(), field.SelectionSet)
+		case "enumValues":
+			result[field.Alias] = q.introspectEnumValueSlice(schemaType.EnumValues(includeDeprecated), field.SelectionSet)
+		case "inputFields":
+			result[field.Alias] = q.introspectInputValueSlice(schemaType.InputFields(), field.SelectionSet)
+		case "ofType":
+			result[field.Alias] = q.introspectType(schemaType.OfType(), field.SelectionSet)
 		}
 	}
 	return result
@@ -147,22 +150,20 @@ func (q *SchemaQueryer) introspectField(fieldDef introspection.Field, selectionS
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			switch field.Name {
-			case "name":
-				result[field.Alias] = fieldDef.Name
-			case "description":
-				result[field.Alias] = fieldDef.Description
-			case "args":
-				result[field.Alias] = q.introspectInputValueSlice(fieldDef.Args, field.SelectionSet)
-			case "type":
-				result[field.Alias] = q.introspectType(fieldDef.Type, field.SelectionSet)
-			case "isDeprecated":
-				result[field.Alias] = fieldDef.IsDeprecated()
-			case "deprecationReason":
-				result[field.Alias] = fieldDef.DeprecationReason()
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		switch field.Name {
+		case "name":
+			result[field.Alias] = fieldDef.Name
+		case "description":
+			result[field.Alias] = fieldDef.Description
+		case "args":
+			result[field.Alias] = q.introspectInputValueSlice(fieldDef.Args, field.SelectionSet)
+		case "type":
+			result[field.Alias] = q.introspectType(fieldDef.Type, field.SelectionSet)
+		case "isDeprecated":
+			result[field.Alias] = fieldDef.IsDeprecated()
+		case "deprecationReason":
+			result[field.Alias] = fieldDef.DeprecationReason()
 		}
 	}
 	return result
@@ -172,18 +173,16 @@ func (q *SchemaQueryer) introspectEnumValue(definition *introspection.EnumValue,
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			switch field.Name {
-			case "name":
-				result[field.Alias] = definition.Name
-			case "description":
-				result[field.Alias] = definition.Description
-			case "isDeprecated":
-				result[field.Alias] = definition.IsDeprecated()
-			case "deprecationReason":
-				result[field.Alias] = definition.DeprecationReason()
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		switch field.Name {
+		case "name":
+			result[field.Alias] = definition.Name
+		case "description":
+			result[field.Alias] = definition.Description
+		case "isDeprecated":
+			result[field.Alias] = definition.IsDeprecated()
+		case "deprecationReason":
+			result[field.Alias] = definition.DeprecationReason()
 		}
 	}
 
@@ -194,18 +193,16 @@ func (q *SchemaQueryer) introspectDirective(directive introspection.Directive, s
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			switch field.Name {
-			case "name":
-				result[field.Alias] = directive.Name
-			case "description":
-				result[field.Alias] = directive.Description
-			case "args":
-				result[field.Alias] = q.introspectInputValueSlice(directive.Args, field.SelectionSet)
-			case "locations":
-				result[field.Alias] = directive.Locations
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		switch field.Name {
+		case "name":
+			result[field.Alias] = directive.Name
+		case "description":
+			result[field.Alias] = directive.Description
+		case "args":
+			result[field.Alias] = q.introspectInputValueSlice(directive.Args, field.SelectionSet)
+		case "locations":
+			result[field.Alias] = directive.Locations
 		}
 	}
 	return result
@@ -215,16 +212,14 @@ func (q *SchemaQueryer) introspectInputValue(iv *introspection.InputValue, selec
 	// a place to store the result
 	result := map[string]interface{}{}
 
-	for _, selection := range selectionSet {
-		if field, ok := selection.(*ast.Field); ok {
-			switch field.Name {
-			case "name":
-				result[field.Alias] = iv.Name
-			case "description":
-				result[field.Alias] = iv.Description
-			case "type":
-				result[field.Alias] = q.introspectType(iv.Type, field.SelectionSet)
-			}
+	for _, field := range graphql.SelectedFields(selectionSet) {
+		switch field.Name {
+		case "name":
+			result[field.Alias] = iv.Name
+		case "description":
+			result[field.Alias] = iv.Description
+		case "type":
+			result[field.Alias] = q.introspectType(iv.Type, field.SelectionSet)
 		}
 	}
 


### PR DESCRIPTION
This PR changes the way fragments are handled when planning queries. Previously, all fragments were "flattened" onto the query providing an easier time optimizing the plan to reduce number of queries. That had the unfortunate side effect of removing any ability to handle or pass on directives applied to a fragment spread (`@if` and `@include` for example).

With this PR, the planner treats fragments as a first class citizen and tries its hardest to split up the query while retaining as many of the original definitions as necessary in case the end services are doing something special with fragment names.

Fixes #36 